### PR TITLE
Validation failed even if there is value in field

### DIFF
--- a/libs/js/Editable.jsx
+++ b/libs/js/Editable.jsx
@@ -101,8 +101,9 @@ export default class Editable extends Component {
   }
   onCancel = () => {
     this.setEditable(false);
-    //reset validation
+    //reset validation and all the changes 
     this.validation = {};
+    this.newValue = this.value;
   }
   setValueToAnchor(value, event){
     this.newValue = value;


### PR DESCRIPTION
steps -

go to type 2)Empty text field, required - Add some text and click ok
then open same field and clear value and click on close icon
again open same editable and click on ok
validation failed even if there is text in field



![screenshot from 2019-01-19 13-22-31](https://user-images.githubusercontent.com/29506306/51424454-d5d4b280-1bf3-11e9-8792-e5d1f4c8f8c4.png)

